### PR TITLE
Make it fail

### DIFF
--- a/V7endpoint/V7endpoint.csproj
+++ b/V7endpoint/V7endpoint.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <AssemblyVersion>1.0.0</AssemblyVersion>
+        <AssemblyVersion>2.0.0</AssemblyVersion>
         <RootNamespace>TheEndpoint</RootNamespace>
         <AssemblyName>TheEndpoint</AssemblyName>
     </PropertyGroup>

--- a/V7endpoint/V7endpoint.csproj
+++ b/V7endpoint/V7endpoint.csproj
@@ -11,10 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql" Version="9.0.2" />
-      <PackageReference Include="NServiceBus" Version="7.8.6" />
-      <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.4.0" />
-      <PackageReference Include="NServiceBus.Persistence.Sql" Version="6.6.5" />
+        <PackageReference Include="Npgsql" Version="9.0.2" />
+        <PackageReference Include="NServiceBus" Version="8.2.4" />
+        <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.1" />
+        <PackageReference Include="NServiceBus.Persistence.Sql" Version="7.0.6" />
     </ItemGroup>
 
 </Project>

--- a/V8endpoint/FixTimeoutMessageVersionBehavior.cs
+++ b/V8endpoint/FixTimeoutMessageVersionBehavior.cs
@@ -1,0 +1,29 @@
+using NServiceBus.Pipeline;
+
+namespace TheEndpoint;
+
+public class FixTimeoutMessageVersionBehavior : Behavior<IIncomingPhysicalMessageContext>
+{
+    public override Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
+    {
+        if (context.Message.Headers.TryGetValue(Headers.IsSagaTimeoutMessage, out var isSagaTimeout))
+        {
+            var enclosedMessageTypes = context.Message.Headers[NServiceBus.Headers.EnclosedMessageTypes];
+            if (enclosedMessageTypes == "TheEndpoint.TheTimeout, TheEndpoint, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null")
+            {
+                enclosedMessageTypes = string.Join(",", enclosedMessageTypes.Split(',').Take(2));
+                context.Message.Headers[NServiceBus.Headers.EnclosedMessageTypes] = enclosedMessageTypes;
+            }
+            
+            var sagaType = context.Message.Headers[NServiceBus.Headers.SagaType];
+            if (sagaType == "TheEndpoint.TheSaga, TheEndpoint, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null")
+            {
+                // This is not really needed, it avoids a warning from the persister that a specific saga type cannot be found and it'll fall back to saga id 
+                sagaType = string.Join(",", sagaType.Split(',').Take(2));
+                context.Message.Headers[NServiceBus.Headers.SagaType] = sagaType;
+            }
+        }
+        
+        return next();
+    }
+}

--- a/V8endpoint/Program.cs
+++ b/V8endpoint/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Npgsql;
 using NpgsqlTypes;
+using TheEndpoint;
 
 var endpointConfiguration = new EndpointConfiguration("Samples.SimpleSaga");
 endpointConfiguration.EnableInstallers();
@@ -14,6 +15,8 @@ dialect.JsonBParameterModifier(
 persistence.ConnectionBuilder(() => new NpgsqlConnection("Server=localhost;Port=5432;Database=db_user;User Id=db_user;Password=your_password;"));
 endpointConfiguration.UseTransport<LearningTransport>();
 endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();
+
+endpointConfiguration.Pipeline.Register(new FixTimeoutMessageVersionBehavior(), "Fix TimeoutMessage versions behavior");
 
 var endpointInstance = await Endpoint.Start(endpointConfiguration);
 

--- a/V8endpoint/V8endpoint.csproj
+++ b/V8endpoint/V8endpoint.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <AssemblyVersion>2.0.0</AssemblyVersion>
+        <AssemblyVersion>1.0.0</AssemblyVersion>
         <RootNamespace>TheEndpoint</RootNamespace>
         <AssemblyName>TheEndpoint</AssemblyName>
     </PropertyGroup>


### PR DESCRIPTION
Hi Mauro,

This reproduces what we get in our case.

Maybe the "downgrading" wasn't completely clear from my initial description of the issue.
I try to clarify a bit more:
- I've upgraded V7 to NSB 8 because our old version of the endpoint that created the timeout was already on NSB8
- Our "downgrading" meant that we had to re-deploy an old version of the endpoint due, therefore I made the Endpoint that starts first (V7)  the higher version, and the V8 the older version to replicate that

In my understanding this would be exactly the same scenario as when an older and a newer version of the same endpoint were deployed at the same time (for upgrades) and the older picked up the timeout that the newer version created.

*edit*
See https://github.com/mauroservienti/TimeoutsWithSideBySideSaga/pull/2
where I rebuilt the identical scenario but with both endpoints NSB7 and it works as expected where the older endpoint can process the newer timeout message